### PR TITLE
Fix encoding issue

### DIFF
--- a/sitegenerator/releases.py
+++ b/sitegenerator/releases.py
@@ -75,7 +75,7 @@ def load_device_metadata(release):
                           'RELEAS_VERSION': '16.04' },
         }"""
     devices_metadata = {}
-    with open(os.path.join(ROOT_DIR, DEVICES_MAPPING)) as f:
+    with open(os.path.join(ROOT_DIR, DEVICES_MAPPING), encoding='utf-8') as f:
         devices_metadata = yaml.load(f.read())
     for device_key in devices_metadata:
         devices_metadata[device_key]['RELEASE_VERSION'] = release


### PR DESCRIPTION
Traceback:
  File "./generate", line 31, in <module>
    main()
  File "/tmp/tmpoWBMbu/snappy-dev-website/sitegenerator/**init**.py",
line 68, in main
    devices = load_device_metadata(release)
  File "/tmp/tmpoWBMbu/snappy-dev-website/sitegenerator/releases.py",
line 79, in load_device_metadata
    devices_metadata = yaml.load(f.read())
  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position
2299: ordinal not in range(128)
